### PR TITLE
POC: iceberg-testing conformance fixtures (submodule)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "iceberg-testing"]
+	path = iceberg-testing
+	url = https://github.com/sungwy/iceberg-testing.git

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -24,6 +24,9 @@ header:
     - "LICENSE"
     - "NOTICE"
     - ".gitattributes"
+    - ".gitmodules"
+    # iceberg-testing is a submodule with its own license
+    - "iceberg-testing"
     - "**/*.json"
     # Generated content by mdbook
     - "website/book"

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -92,6 +92,7 @@ pretty_assertions = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 serde_arrow = { version = "0.14", features = ["arrow-58"] }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 
 [package.metadata.cargo-machete]

--- a/crates/iceberg/tests/common/mod.rs
+++ b/crates/iceberg/tests/common/mod.rs
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shared helpers for the iceberg-testing conformance suite.
+//!
+//! The fixtures are language-neutral: a static input plus the expected result the spec
+//! fixes for it, pinned in the `iceberg-testing/` submodule. Each surface has its own test
+//! module. Cases this crate does not satisfy yet are listed as expected failures with a
+//! tracking issue. The submodule must be checked out (`git submodule update --init`);
+//! otherwise the tests skip.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+/// Root of the pinned fixtures, relative to the iceberg crate.
+pub fn fixtures() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../iceberg-testing/table-spec")
+}
+
+pub fn load_jsonl(path: &Path) -> Vec<Value> {
+    let text =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    text.lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("valid JSONL"))
+        .collect()
+}
+
+/// Record one case against its expected-failure list: a listed case is allowed to fail; any
+/// other failure is a real conformance miss.
+pub fn record(
+    id: &str,
+    outcome: Result<(), String>,
+    xfail: &HashMap<&str, &str>,
+    failures: &mut Vec<String>,
+) {
+    match (outcome, xfail.get(id)) {
+        (Ok(()), None) => {}
+        (Ok(()), Some(reason)) => {
+            println!("XPASS (remove from expected-failure list): {id} -- {reason}")
+        }
+        (Err(_), Some(reason)) => println!("expected failure: {id} -- {reason}"),
+        (Err(msg), None) => failures.push(format!("{id}: {msg}")),
+    }
+}

--- a/crates/iceberg/tests/conformance_bucket_hash.rs
+++ b/crates/iceberg/tests/conformance_bucket_hash.rs
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Bucket-transform conformance: the Appendix B 32-bit hash that bucket[N] builds on.
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{fixtures, load_jsonl, record};
+use iceberg::spec::{Datum, PrimitiveLiteral, Transform};
+use iceberg::transform::{BoxedTransformFunction, create_transform_function};
+use serde_json::Value;
+
+const BUCKETS: i64 = 2_000_003; // large prime; comparing bucket[N] avoids needing the raw hash API
+
+#[test]
+fn bucket_hash() {
+    let path = fixtures().join("transforms/bucket/cases.jsonl");
+    if !path.exists() {
+        eprintln!("iceberg-testing submodule absent; skipping (git submodule update --init)");
+        return;
+    }
+    // iceberg-rust already serializes the minimal-byte decimal, so there are no expected
+    // failures here -- including the byte-boundary decimals some implementations get wrong.
+    let xfail = HashMap::new();
+    let func = create_transform_function(&Transform::Bucket(BUCKETS as u32)).unwrap();
+
+    let mut failures = Vec::new();
+    for case in load_jsonl(&path) {
+        let id = case["id"].as_str().unwrap();
+        record(id, check(&case, &func), &xfail, &mut failures);
+    }
+    assert!(
+        failures.is_empty(),
+        "bucket-hash conformance failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+fn check(case: &Value, func: &BoxedTransformFunction) -> Result<(), String> {
+    let datum = datum(
+        case["type"].as_str().unwrap(),
+        case["value"].as_str().unwrap(),
+    );
+    let result = func
+        .transform_literal_result(&datum)
+        .map_err(|e| e.to_string())?;
+    let got = match result.literal() {
+        PrimitiveLiteral::Int(bucket) => i64::from(*bucket),
+        other => return Err(format!("bucket result not an int: {other:?}")),
+    };
+    let expected = (case["hash"].as_i64().unwrap() & 0x7FFF_FFFF) % BUCKETS;
+    if got == expected {
+        Ok(())
+    } else {
+        Err(format!("bucket {got} != expected {expected}"))
+    }
+}
+
+/// Build the typed value the bucket transform hashes from the fixture's string form.
+fn datum(type_str: &str, value: &str) -> Datum {
+    match type_str {
+        "int" => Datum::int(value.parse::<i32>().unwrap()),
+        "long" => Datum::long(value.parse::<i64>().unwrap()),
+        "string" => Datum::string(value),
+        "date" => Datum::date_from_str(value).unwrap(),
+        "time" => Datum::time_from_str(value).unwrap(),
+        "timestamp" => Datum::timestamp_from_str(value).unwrap(),
+        "uuid" => Datum::uuid_from_str(value).unwrap(),
+        "binary" => Datum::binary(hex(value)),
+        t if t.starts_with("decimal") => Datum::decimal_from_str(value).unwrap(),
+        t if t.starts_with("fixed") => Datum::fixed(hex(value)),
+        other => panic!("unsupported type {other}"),
+    }
+}
+
+fn hex(s: &str) -> Vec<u8> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).expect("valid hex"))
+        .collect()
+}

--- a/crates/iceberg/tests/conformance_type_strings.rs
+++ b/crates/iceberg/tests/conformance_type_strings.rs
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Type-string conformance: parse the input and re-serialize to the canonical schema-JSON form.
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{fixtures, load_jsonl, record};
+use iceberg::spec::PrimitiveType;
+use serde_json::Value;
+
+// Cases iceberg-rust does not satisfy yet: geometry/geography are not implemented,
+// fixed[...] rejects internal whitespace, and decimal precision > 38 is not rejected.
+// (Decimal whitespace, by contrast, is accepted.)
+fn expected_failures() -> HashMap<&'static str, &'static str> {
+    HashMap::from([
+        (
+            "geometry-default",
+            "geometry type not supported yet; apache/iceberg-rust#1884",
+        ),
+        (
+            "geometry-unquoted-crs",
+            "geometry type not supported yet; apache/iceberg-rust#1884",
+        ),
+        (
+            "fixed-space-around",
+            "rejects whitespace inside fixed[...] brackets; type-string whitespace, cf. apache/iceberg#16798",
+        ),
+        (
+            "decimal-precision-over-max",
+            "does not reject decimal precision > 38 (spec: precision must be 38 or less; Java rejects it)",
+        ),
+    ])
+}
+
+#[test]
+fn type_strings() {
+    let dir = fixtures().join("types");
+    if !dir.exists() {
+        eprintln!("iceberg-testing submodule absent; skipping (git submodule update --init)");
+        return;
+    }
+    let xfail = expected_failures();
+    let mut failures = Vec::new();
+    for kind in ["decimal", "fixed", "geometry"] {
+        for case in load_jsonl(&dir.join(kind).join("cases.jsonl")) {
+            let id = case["id"].as_str().unwrap();
+            record(id, check(&case), &xfail, &mut failures);
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "type-string conformance failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+fn check(case: &Value) -> Result<(), String> {
+    let input = case["input"].as_str().unwrap();
+    let parsed: Result<PrimitiveType, _> = serde_json::from_value(Value::String(input.to_string()));
+    if !case["accept"].as_bool().unwrap() {
+        return match parsed {
+            Ok(t) => Err(format!("expected reject, parsed to {t:?}")),
+            Err(_) => Ok(()),
+        };
+    }
+    let parsed = parsed.map_err(|e| format!("expected parse, got error: {e}"))?;
+    if let Some(fields) = case.get("parsed") {
+        let ok = match &parsed {
+            PrimitiveType::Decimal { precision, scale } => {
+                u64::from(*precision) == fields["precision"].as_u64().unwrap()
+                    && u64::from(*scale) == fields["scale"].as_u64().unwrap()
+            }
+            PrimitiveType::Fixed(length) => *length == fields["length"].as_u64().unwrap(),
+            _ => true,
+        };
+        if !ok {
+            return Err(format!("parsed {parsed:?} != {fields}"));
+        }
+    }
+    // Re-serialize through serde, the schema-JSON form, not Display.
+    let canonical = case["canonical"].as_str().unwrap();
+    match serde_json::to_value(&parsed).map_err(|e| e.to_string())? {
+        Value::String(s) if s == canonical => Ok(()),
+        other => Err(format!("serialized {other} != canonical {canonical:?}")),
+    }
+}


### PR DESCRIPTION
POC pinning the language-neutral conformance fixtures from sungwy/iceberg-testing as a git submodule (`iceberg-testing/`).

Test Surfaces: type-string parse + re-serialize, the Appendix B bucket-hash Known-Answer-Test (incl. byte-boundary decimals), and delete-file decode by field-id